### PR TITLE
Refactoring build configurations

### DIFF
--- a/VS15/chapro_dll.vcxproj
+++ b/VS15/chapro_dll.vcxproj
@@ -170,6 +170,8 @@
     <ClCompile Include="..\ciirfb_design.c" />
     <ClCompile Include="..\ciirfb_prepare.c" />
     <ClCompile Include="..\ciirfb_process.c" />
+    <ClCompile Include="..\dciirfb_prepare.c" />
+    <ClCompile Include="..\dciirfb_process.c" />
     <ClCompile Include="..\fft.c" />
     <ClCompile Include="..\firfb_prepare.c" />
     <ClCompile Include="..\firfb_process.c" />

--- a/VS15/chapro_dll.vcxproj
+++ b/VS15/chapro_dll.vcxproj
@@ -71,7 +71,6 @@
       <PreprocessorDefinitions>SHA;WIN32;NDEBUG;_WINDOWS;_USRDLL;CHAPRO_DLL_EXPORTS;_CRT_SECURE_NO_WARNINGS;ZLIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>false</StringPooling>
       <MinimalRebuild>true</MinimalRebuild>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <FloatingPointModel>Fast</FloatingPointModel>
       <PrecompiledHeaderOutputFile />
@@ -122,7 +121,6 @@
       <PreprocessorDefinitions>SHA;WIN32;_DEBUG;_WINDOWS;_USRDLL;CHAPRO_DLL_EXPORTS;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>Default</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <FloatingPointModel>Fast</FloatingPointModel>
       <PrecompiledHeaderOutputFile />
       <AssemblerListingLocation />

--- a/VS15/chapro_dll.vcxproj.filters
+++ b/VS15/chapro_dll.vcxproj.filters
@@ -78,6 +78,12 @@
     <ClCompile Include="..\rfft.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\dciirfb_prepare.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\dciirfb_process.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\cha_ff.h">

--- a/VS15/chapro_lib.vcxproj
+++ b/VS15/chapro_lib.vcxproj
@@ -58,7 +58,6 @@
       <AdditionalIncludeDirectories>c:\usr\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <FloatingPointModel>Fast</FloatingPointModel>
       <PrecompiledHeaderOutputFile>.\Release/chapro_lib.pch</PrecompiledHeaderOutputFile>

--- a/VS15/chapro_lib.vcxproj
+++ b/VS15/chapro_lib.vcxproj
@@ -77,14 +77,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <OutputFile>.\Release/chapro_lib.bsc</OutputFile>
     </Bscmake>
-    <PostBuildEvent>
-      <Message>Install SIGPRO</Message>
-      <Command>Copy $(TargetPath) ..\..\lib
-Copy $(TargetPath) c:\usr\lib
-Copy ..\chapro.h ..\..\include
-Copy ..\chapro.h c:\usr\include
-</Command>
-    </PostBuildEvent>
+    <PostBuildEvent />
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
@neeste @DanielRasetshwane 

*These changes only apply to the VS15 project files chapro_dll and chapro_lib, not to their VS9 companions*

- I changed the runtime library to its default setting (multi threaded dll). Most if not all of the libraries I link with use this setting, and if multiple linked libraries do not share a common runtime warnings are produced.
- I added the files dciirfb_prepare.c and dciirfb_process.c to the build for chapro_dll. I'm guessing that these were intended to be included in the build because a linking error is produced without them.
- I removed the post build event for the release chapro_lib since it did not apply to the directories on my machine.
