### PR TITLE
Do the firfb functions cope with non power of two arguments?

### DIFF
--- a/firfb_prepare.c
+++ b/firfb_prepare.c
@@ -115,6 +115,8 @@ cha_firfb_prepare(CHA_PTR cp, double *cf, int nc, double fs,
     if (cs <= 0) {
         return (1);
     }
+	if (cs % 2 != 0 || nw % 2 != 0)
+		return 1;
     cha_prepare(cp);
     CHA_IVAR[_cs] = cs;
     CHA_DVAR[_fs] = fs;


### PR DESCRIPTION
@neeste 
I've been running into seg faults when passing a window size and/or chunk size that is not a power of two. Is this expected? Would the following change protect against such a requirement without imposing additional restraints?